### PR TITLE
Add additional arguments to fetchData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -80,7 +80,12 @@ export default function initializeClient(createApp, clientOpts) {
             // loose of an approach, a comprehensive approach is available at:
             //   https://ssr.vuejs.org/en/data.html#client-data-fetching
             const components = router.getMatchedComponents(to);
-            const fetchData = c => c.fetchData && c.fetchData({ store, route: to });
+            const fetchData = c => c.fetchData && c.fetchData({
+                app,
+                route: to,
+                router,
+                store,
+            });
             return opts.middleware(to, from, store)
                 .then(() => Promise.all(components.map(fetchData)))
                 .then(() => opts.postMiddleware(to, from, store))

--- a/src/entry-server.js
+++ b/src/entry-server.js
@@ -40,8 +40,10 @@ export default function initializeServer(createApp, serverOpts) {
                 }
 
                 const fetchData = c => c.fetchData && c.fetchData({
-                    store,
+                    app,
                     route: router.currentRoute,
+                    router,
+                    store,
                 });
 
                 // Execute all provided middleware prior to fetchData


### PR DESCRIPTION
In my specific instance, I needed access to the `app` in `fetchData` so I could access `app.$i18n` for dynamically loading translations.  Figured it would be the most future proof to just expose `app`/`router`/`store` like we do for the middlewares.

Should be 100% backwards compatible, as it's just new fields on the existing parameter to `fetchData`