### PR TITLE
Add flag for inclusion of babel-loader

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -90,11 +90,14 @@ module.exports = {
                         loader: '@kazupon/vue-i18n-loader',
                     }] : []),
 
-                    {
+                    // Only include babelLoader if specified - useful to turn
+                    // this off for the server build
+                    ...(config.babelLoader ? [{
                         test: /\.js$/,
                         loader: 'babel-loader',
                         exclude: /node_modules/,
-                    },
+                    }] : []),
+
                     {
                         test: /\.css$/,
                         use: getCssLoaders(config),

--- a/build/webpack.client.config.js
+++ b/build/webpack.client.config.js
@@ -16,6 +16,7 @@ module.exports = function getClientConfig(configOpts) {
         i18nBlocks: false,
         theme: null,
         sassLoaderData: null,
+        babelLoader: true,
     }, configOpts);
 
     const clientConfig = merge(getBaseConfig(config), {

--- a/build/webpack.server.config.js
+++ b/build/webpack.server.config.js
@@ -31,6 +31,7 @@ module.exports = function getServerConfig(configOpts) {
         i18nBlocks: false,
         theme: null,
         sassLoaderData: null,
+        babelLoader: false,
     }, configOpts);
 
     const serverConfig = merge(getBaseConfig(config), {

--- a/build/webpack.server.config.js
+++ b/build/webpack.server.config.js
@@ -31,7 +31,7 @@ module.exports = function getServerConfig(configOpts) {
         i18nBlocks: false,
         theme: null,
         sassLoaderData: null,
-        babelLoader: false,
+        babelLoader: true,
     }, configOpts);
 
     const serverConfig = merge(getBaseConfig(config), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",


### PR DESCRIPTION
* Added a flag to allow the client app to opt in or out of babel-loader on the client/server builds
* Defaults to included for both builds for backwards compatibility
* We will be turning it off for our server build in PWA since node 8 supports just about everything we'd want to use (including async/await)
