### PR TITLE
Inline SVG support

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -125,16 +125,22 @@ module.exports = {
                             },
                         },
                     },
-                    // See: https://iamakulov.com/notes/optimize-images-webpack/
                     {
                         test: /\.svg$/,
-                        use: {
-                            loader: 'svg-url-loader',
-                            options: {
-                                limit: 8192,
-                                noquotes: true,
+                        oneOf: [{
+                            resourceQuery: /inline/,
+                            use: 'svg-inline-loader',
+                        }, {
+                            test: /\.svg$/,
+                            use: {
+                                // See: https://iamakulov.com/notes/optimize-images-webpack/
+                                loader: 'svg-url-loader',
+                                options: {
+                                    limit: 8192,
+                                    noquotes: true,
+                                },
                             },
-                        },
+                        }],
                     },
                 ],
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7923,6 +7923,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-html-tokenizer": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
+      "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4="
+    },
     "sisteransi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -8326,6 +8331,29 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svg-inline-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz",
+      "integrity": "sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==",
+      "requires": {
+        "loader-utils": "^0.2.11",
+        "object-assign": "^4.0.1",
+        "simple-html-tokenizer": "^0.1.1"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        }
       }
     },
     "svg-url-loader": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mini-css-extract-plugin": "0.4.2",
     "node-sass": "4.9.2",
     "sass-loader": "7.1.0",
+    "svg-inline-loader": "0.8.0",
     "svg-url-loader": "2.3.2",
     "vue": "2.5.17",
     "vue-i18n": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",


### PR DESCRIPTION
Adds the ability to use a webpack resourceQuery to load specified SVG's inline instead of converting them to a URL for use in an `<img>` tag.  This is how we can style them with CSs when needed.

```
// Will result in either an SVG file path in dist/ or a base-64 encoded data URI.
// Both of which will require rendering as an img src
const logo = require('logo.svg');
<img src="${logo}" /> 

// Will result in the SVG markup being loaded for inline rendering
const logo = require('logo.svg?inline');
<span>${logo}</span>
```