### PR TITLE
Enhance routing error handling client side

### DIFF
--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -138,8 +138,14 @@ export default function initializeClient(createApp, clientOpts) {
                     opts.logger.error(e);
                     if (e instanceof Error) {
                         next(e);
+                    } else if (typeof e === 'string') {
+                        next(new Error(e));
                     } else {
-                        next(false);
+                        try {
+                            next(new Error(JSON.stringify(e)));
+                        } catch (e2) {
+                            next(new Error('Unknown routing error'));
+                        }
                     }
                 });
         });


### PR DESCRIPTION
Avoid using `next(false)` since it doesn't propagate to the global `router.onError` handler

https://router.vuejs.org/guide/advanced/navigation-guards.html#global-guards