### PR TITLE
Updates to support multiple renderers

### DIFF
--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -13,9 +13,12 @@ export default function initializeClient(createApp, clientOpts) {
         logger: console,
     }, clientOpts);
 
-    let initialState = null;
+    let { initialState } = opts;
 
     if (isString(opts.initialStateMetaTag)) {
+        if (initialState) {
+            opts.logger.error('initialState and initialStateMetaTag should not be used together');
+        }
         try {
             const meta = document.querySelector(`meta[name="${opts.initialStateMetaTag}"]`);
             initialState = JSON.parse(meta.getAttribute('content'));

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, global-require, import/no-unresolved, import/no-dynamic-require */
+
 const fs = require('fs');
 const path = require('path');
 const LRU = require('lru-cache');
@@ -11,7 +13,6 @@ const errorHandler = (err, res, cb) => {
     } else {
         // Render Error Page or Redirect
         res.status(500).send('500 | Internal Server Error');
-        /* eslint-disable no-console */
         console.error(err);
         console.error(err.stack);
     }
@@ -19,7 +20,8 @@ const errorHandler = (err, res, cb) => {
 };
 
 // Base config - extended via client argument to initVueRenderer
-const config = {
+const defaults = {
+    name: 'default',
     errorHandler,
     i18nDirective: false,
     isLocal: process.env.NODE_ENV === 'local',
@@ -38,29 +40,28 @@ const config = {
     serverBundle: null,
 };
 
-let cache;
-let renderer;
-let readyPromise;
+const caches = {};
+const renderers = {};
+const readyPromises = {};
 
-function createRenderer(bundle, options) {
-    /* eslint-disable global-require */
+function createRenderer(bundle, options, config) {
     const t = config.i18nDirective ?
         require('vue-i18n-extensions').directive :
         null;
 
-    if (cache) {
+    if (caches[config.name]) {
         console.log(
-            'Recreating the Vue SSR BundleRenderer, clearing the component cache',
-            'and re-creating',
+            `Recreating the "${config.name}" Vue SSR BundleRenderer, clearing`,
+            'the component cache and re-creating',
         );
-        cache.reset();
-        cache = null;
+        caches[config.name].reset();
+        caches[config.name] = null;
     }
 
     const prettySize = Math.round(config.componentCacheMaxSize / 1024);
     const prettyAge = Math.round(config.componentCacheMaxAge / 1000);
     console.log(`Creating component cache: maxSize ${prettySize}Kb, maxAge ${prettyAge}s`);
-    cache = LRU({
+    caches[config.name] = LRU({
         length(n, key) {
             // Vue components come in as an object with an html key containing
             // the SSR output
@@ -80,15 +81,15 @@ function createRenderer(bundle, options) {
     });
 
     return createBundleRenderer(bundle, Object.assign(options, {
-        cache,
+        cache: caches[config.name],
         runInNewContext: false,
         // Only include the t directive when specified
         ...(t ? { directives: { t } } : {}),
     }, config.rendererOpts));
 }
 
-function renderToString(context, res, cb) {
-    renderer.renderToString(context,
+function renderToString(config, context, res, cb) {
+    renderers[config.name].renderToString(context,
         (err, html) => {
             if (err) {
                 config.errorHandler(err, res, cb);
@@ -100,8 +101,8 @@ function renderToString(context, res, cb) {
         e => config.errorHandler(e, res, cb));
 }
 
-function renderToStream(context, res, cb) {
-    const stream = renderer.renderToStream(context);
+function renderToStream(config, context, res, cb) {
+    const stream = renderers[config.name].renderToStream(context);
     stream.on('data', data => res.write(data.toString()));
     stream.on('end', () => {
         res.end();
@@ -110,7 +111,7 @@ function renderToStream(context, res, cb) {
     stream.on('error', err => config.errorHandler(err, res, cb));
 }
 
-function render(clientManifest, req, res) {
+function render(config, clientManifest, req, res) {
     const s = Date.now();
 
     console.log('\n\nVue request started', new Date().toISOString());
@@ -129,11 +130,13 @@ function render(clientManifest, req, res) {
     // Render the appropriate Vue components into the renderer template
     // using the server render logic in entry-server.js
     const renderFn = config.stream ? renderToStream : renderToString;
-    renderFn(context, res, () => {
+
+    console.log(`Rendering from ${config.name} renderer!`);
+    renderFn(config, context, res, () => {
         if (config.componentCacheDebug) {
             console.log('Component cache stats:');
-            console.log('  length:', cache.length);
-            console.log('  keys:', cache.keys().join(','));
+            console.log('  length:', caches[config.name].length);
+            console.log('  keys:', caches[config.name].keys().join(','));
         }
         console.log('Vue request ended', new Date().toISOString());
         console.log(`SSR request took: ${Date.now() - s}ms`);
@@ -141,20 +144,28 @@ function render(clientManifest, req, res) {
 }
 
 module.exports = function initVueRenderer(app, configOpts) {
-    /* eslint-disable global-require, import/no-unresolved, import/no-dynamic-require */
-    Object.assign(config, configOpts);
+    const config = Object.assign({}, defaults, configOpts);
+
+    if (renderers[config.name]) {
+        console.error(`[ERROR] There already exists a "${config.name}" renderer, overwriting...`);
+    } else {
+        console.log(`Creating "${config.name}" renderer...`);
+    }
 
     // In development: setup the dev server with watch and hot-reload,
     // and create a new renderer on bundle / index template update.
     if (config.hmr) {
-        readyPromise = require('./setup-dev-server')(
+        readyPromises[config.name] = require('./setup-dev-server')(
             app,
             config,
-            (bundle, options) => { renderer = createRenderer(bundle, options); },
+            (bundle, options) => {
+                renderers[config.name] = createRenderer(bundle, options, config);
+            },
         );
         return (req, res) => {
             // Make dev server wait on webpack builds
-            readyPromise.then(({ clientManifest }) => render(clientManifest, req, res));
+            readyPromises[config.name]
+                .then(({ clientManifest }) => render(config, clientManifest, req, res));
         };
     }
 
@@ -163,8 +174,8 @@ module.exports = function initVueRenderer(app, configOpts) {
     const bundle = require(path.resolve(config.serverBundle));
     const clientManifest = require(path.resolve(config.clientManifest));
 
-    renderer = createRenderer(bundle, { template, clientManifest });
+    renderers[config.name] = createRenderer(bundle, { template, clientManifest }, config);
     return function renderVueRoute(req, res) {
-        return render(clientManifest, req, res);
+        return render(config, clientManifest, req, res);
     };
 };

--- a/src/setup-dev-server.js
+++ b/src/setup-dev-server.js
@@ -51,16 +51,20 @@ module.exports = function setupDevServer(app, config, cb) {
         update();
     });
 
-    // modify client config to work with hot middleware
-    clientConfig.entry.app = [
-        'webpack-hot-middleware/client',
-        clientConfig.entry.app,
-    ];
-    clientConfig.output.filename = '[name].js';
-    clientConfig.plugins.push(
-        new webpack.HotModuleReplacementPlugin(),
-        new webpack.NoEmitOnErrorsPlugin(),
-    );
+    // Modify client config to work with hot middleware.  Only do this once in
+    // the case of multiple renderers
+    if (clientConfig.entry.app && clientConfig.entry.app[0] !== 'webpack-hot-middleware/client') {
+        clientConfig.entry.app = [
+            'webpack-hot-middleware/client',
+            clientConfig.entry.app,
+        ];
+        clientConfig.output.filename = '[name].js';
+        clientConfig.plugins.push(
+            new webpack.HotModuleReplacementPlugin(),
+            new webpack.NoEmitOnErrorsPlugin(),
+        );
+    }
+
 
     // dev middleware
     console.error('Launching client webpack build');


### PR DESCRIPTION
Allow's creation and usage of multiple named renderers, used for orchestration routes.

Example:

```
const createRenderer = require('vue-ssr-build/src/renderer');

// "orchestration" renderer
app.get('/orchestration/*', createRenderer(app, { name: 'orchestration }));

// Not passing a name will be the "default" renderer
app.get('*', createRenderer(app));```