### PR TITLE
Fix HMR when using multiple renderers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/setup-dev-server.js
+++ b/src/setup-dev-server.js
@@ -51,20 +51,16 @@ module.exports = function setupDevServer(app, config, cb) {
         update();
     });
 
-    // Modify client config to work with hot middleware.  Only do this once in
-    // the case of multiple renderers
-    if (clientConfig.entry.app && clientConfig.entry.app[0] !== 'webpack-hot-middleware/client') {
-        clientConfig.entry.app = [
-            'webpack-hot-middleware/client',
-            clientConfig.entry.app,
-        ];
-        clientConfig.output.filename = '[name].js';
-        clientConfig.plugins.push(
-            new webpack.HotModuleReplacementPlugin(),
-            new webpack.NoEmitOnErrorsPlugin(),
-        );
-    }
-
+    // modify client config to work with hot middleware
+    clientConfig.entry.app = [
+        'webpack-hot-middleware/client',
+        clientConfig.entry.app,
+    ];
+    clientConfig.output.filename = '[name].js';
+    clientConfig.plugins.push(
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.NoEmitOnErrorsPlugin(),
+    );
 
     // dev middleware
     console.error('Launching client webpack build');


### PR DESCRIPTION
When using multiple renderers, there was an issue with the webpack builds conflicting with one another, and the wrong templates getting included.  This fixes that up, with one caveat:

* When using multiple renderers, you will not get auto updates for template changes for non-default renderers
  * However - the latest versions of non-default templates will be picked up when the default template changes, and causes a re-creation of the renderer