### PR TITLE
Add support for true-instance aware modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -43,7 +43,7 @@ export default function initializeClient(createApp, clientOpts) {
         // module name
         const getModuleName = (c, route) => (
             typeof c.vuex.moduleName === 'function' ?
-                c.vuex.moduleName(route) :
+                c.vuex.moduleName({ $route: route }) :
                 c.vuex.moduleName
         );
 

--- a/src/entry-server.js
+++ b/src/entry-server.js
@@ -36,7 +36,7 @@ export default function initializeServer(createApp, serverOpts) {
                             // Allow a function to be passed that can generate a route-aware
                             // module name
                             const moduleName = typeof c.vuex.moduleName === 'function' ?
-                                c.vuex.moduleName(router.currentRoute) :
+                                c.vuex.moduleName({ $route: router.currentRoute }) :
                                 c.vuex.moduleName;
                             opts.logger.info('Registering dynamic Vuex module:', moduleName);
                             store.registerModule(moduleName, c.vuex.module, {


### PR DESCRIPTION
This allows us to use instance information other than `this.$route`.  At the route-component level, we're still stuck with only using route-specific info since we won't have an instance or props, etc.  However, for nested modules we can use prop-based stores.