### PR TITLE
Re-enable one-var from airbnb

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,8 +39,6 @@ module.exports = {
         'no-console': 'error',
         // Allow unary ++ and -- operators
         'no-plusplus': 'off',
-        // Don't enforce one-var for now
-        'one-var': 'off',
         // Put operators at the end of the lint (?, :, &&, ||)
         'operator-linebreak': ['error', 'after'],
         // Don't enforce a blank line or not at the beginning of a block

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",


### PR DESCRIPTION
I'm not entirely sure why we had this off to being with, but we're coded to it, so we can just align with AirBnb.