### PR TITLE
Add support for insertInto option

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -165,10 +165,13 @@ module.exports = {
                     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
                 }),
                 new VueLoaderPlugin(),
-                new MiniCssExtractPlugin({
-                    filename: isProd ? 'app.[contenthash].css' : 'app.css',
-                    chunkFilename: isProd ? '[name].[contenthash].css' : '[name].css',
-                }),
+                ...(config.extractCss ? [
+                    new MiniCssExtractPlugin({
+                        filename: isProd ? 'app.[contenthash].css' : 'app.css',
+                        chunkFilename: isProd ? '[name].[contenthash].css' : '[name].css',
+                        insertInto: config.insertInto,
+                    }),
+                ] : []),
             ],
         };
     },

--- a/build/webpack.client.config.js
+++ b/build/webpack.client.config.js
@@ -13,6 +13,7 @@ module.exports = function getClientConfig(configOpts) {
         type: 'client',
         rootDir: null,
         extractCss: false,
+        insertInto: null,
         enablePostCss: false,
         postCssOpts: null,
         i18nBlocks: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",


### PR DESCRIPTION
This fixes issues with the orchestrated header where the main `app.css` stylesheet lives in `<body>`.  `MiniCSSExtractPlugin` currently only supports adding async loaded stylesheets to `<head>` which can break the cascade since they come before `app.css` in orchestrated scenarios.

This relies on a local change to mini-css-extract-plugin at the moment.  Going to open an issue/PR on their repo to see if they're open to a PR - or else we may need to temporarily fork the repo.  See https://github.com/webpack-contrib/mini-css-extract-plugin/issues/370

Opening a PR is a bit intensive, so need to tackle that separately