### PR TITLE
Updating `env` to new babel syntax

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,7 @@ module.exports = (api) => {
         env: {
             test: {
                 presets: [
-                    ['env', {
+                    ['@babel/preset-env', {
                         modules: 'commonjs',
                     }],
                 ],


### PR DESCRIPTION
Missed this the first time around, whoops!