### PR TITLE
Add support for component shouldIgnoreRouteUpdate method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,13 @@ module.exports = {
         'no-console': 'error',
         // Allow unary ++ and -- operators
         'no-plusplus': 'off',
+        // Allow up to 8 props, but mostly rely on max line length to limit this
+        'object-curly-newline': ['error', {
+            ObjectExpression: { minProperties: 8, multiline: true, consistent: true },
+            ObjectPattern: { minProperties: 8, multiline: true, consistent: true },
+            ImportDeclaration: { minProperties: 8, multiline: true, consistent: true },
+            ExportDeclaration: { minProperties: 8, multiline: true, consistent: true },
+        }],
         // Put operators at the end of the lint (?, :, &&, ||)
         'operator-linebreak': ['error', 'after'],
         // Don't enforce a blank line or not at the beginning of a block

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",
@@ -13,6 +13,8 @@
     "url": "git+https://github.com/brophdawg11/vue-ssr-build.git"
   },
   "scripts": {
+    "bump": "npm --no-git-tag-version version minor",
+    "bump:patch": "npm --no-git-tag-version version patch",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
This allows route-level components to specify an optional `shouldIgnoreRouteUpdate` method alongside `fetchData` that should return `true` if the component wishes to skip `middleware`/`fetchData`/`postMiddleware` on a route update (i.e., if it's only a query param or hash change).  The method takes the same arguments as `fetchData`