### PR TITLE
Fix vuex bug introduced in 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -87,7 +87,9 @@ export default function initializeClient(createApp, clientOpts) {
         // After routing, unregister any dynamic Vuex modules from prior components
         router.afterEach((to, from) => {
             const fetchDataArgs = { app, route: to, router, store, from };
-            const toModuleNames = router.getMatchedComponents(to).map(c => getModuleName(c, to));
+            const toModuleNames = router.getMatchedComponents(to)
+                .filter(c => 'vuex' in c)
+                .map(c => getModuleName(c, to));
             router.getMatchedComponents(from)
                 .filter(c => 'vuex' in c)
                 .filter(c => !shouldIgnoreRouteUpdate(c, fetchDataArgs))


### PR DESCRIPTION
Found an issue with changes in 2.4.0 where client side routing to route-level components that did not specify a `vuex` property was throwing an error due to not being defensive