### PR TITLE
Proxy fetchData resolutions to next callback in entry-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -128,7 +128,9 @@ export default function initializeClient(createApp, clientOpts) {
         router.beforeResolve((to, from, next) => {
             const routeUpdateStr = `${from.fullPath} -> ${to.fullPath}`;
             const fetchDataArgs = { app, route: to, router, store, from };
-            const fetchData = c => isFunction(c.fetchData) && c.fetchData(fetchDataArgs);
+            // Call fetchData for any routes that define it, otherwise resolve with
+            // null to allow routing via next(null)
+            const fetchData = c => (isFunction(c.fetchData) ? c.fetchData(fetchDataArgs) : null);
             const components = router.getMatchedComponents(to)
                 .filter(c => !shouldIgnoreRouteUpdate(c, fetchDataArgs));
 

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -142,8 +142,10 @@ export default function initializeClient(createApp, clientOpts) {
             return Promise.resolve()
                 .then(() => opts.middleware(to, from, store, app))
                 .then(() => Promise.all(components.map(fetchData)))
-                .then(() => opts.postMiddleware(to, from, store, app))
-                .then(() => next())
+                // Proxy results through the chain
+                .then(results => opts.postMiddleware(to, from, store, app).then(() => results))
+                // Call next with the first non-null resolved value from fetchData
+                .then(results => next(results.find(r => r != null)))
                 .catch((e) => {
                     opts.logger.error('Error fetching component data, preventing routing');
                     opts.logger.error(e);


### PR DESCRIPTION
Allow client side fetchData calls to control the routing `beforeResolve` behavior via passing the resolved value through to the next callback.  This way, a route can:

```js
// Let the routing operation proceed normally
async fetchData() {
    ...
    return;
}

// Abort the routing operation via next(false)
async fetchData() {
    ...
    return false;
}

// Redirect the routing operation using a path string
async fetchData() {
    ...
    return 'new-url';
}

// Redirect the routing operation using a route object
async fetchData() {
    ...
    return {
        path: 'new-url',
        replace: true,
    };
}
```
