### PR TITLE
Support performance mark/measure calls during client side routing

### DIFF
--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -9,13 +9,7 @@ const shouldIgnoreRouteUpdate = (c, args) => (
 let enablePerfMarks = false;
 
 const PERF_PREFIX = 'urbnperf';
-const perfEnabled = () => (
-    enablePerfMarks &&
-    window.performance !== null &&
-    isFunction(window.performance.mark) &&
-    isFunction(window.performance.measure) &&
-    isFunction(window.performance.clearMarks)
-);
+const perfEnabled = () => enablePerfMarks && window.performance !== null;
 
 // Look up the current perf mark of the format urbnperf|*|start
 const getCurrentPerfMark = () => window.performance.getEntriesByType('mark')
@@ -40,6 +34,8 @@ function perfInit(to, from) {
     window.performance.mark(`${PERF_PREFIX}|${from.name}->${to.name}|start`);
 }
 
+// Issue a performance.measure call for the given name using the most recent
+// 'start' mark
 export function perfMeasure(name) {
     if (!perfEnabled()) {
         return;

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -193,7 +193,6 @@ export default function initializeClient(createApp, clientOpts) {
         // Approach based on:
         //   https://ssr.vuejs.org/en/data.html#client-data-fetching
         router.beforeResolve((to, from, next) => {
-            perfMeasure('beforeResolve');
             const routeUpdateStr = `${from.fullPath} -> ${to.fullPath}`;
             const fetchDataArgs = { app, route: to, router, store, from };
             // Call fetchData for any routes that define it, otherwise resolve with
@@ -210,6 +209,7 @@ export default function initializeClient(createApp, clientOpts) {
 
             opts.logger.debug(`Running middleware/fetchData for route update ${routeUpdateStr}`);
             return Promise.resolve()
+                .then(() => perfMeasure('beforeResolve'))
                 .then(() => opts.middleware(to, from, store, app))
                 .then(() => perfMeasure('middleware-complete'))
                 .then(() => Promise.all(components.map(fetchData)))

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -1,9 +1,62 @@
-import { find, isFunction, isString } from 'lodash-es';
+import { find, last, isFunction, isString } from 'lodash-es';
 
 const shouldIgnoreRouteUpdate = (c, args) => (
     isFunction(c.shouldIgnoreRouteUpdate) &&
     c.shouldIgnoreRouteUpdate(args) === true
 );
+
+export const hasPerformanceAPI = () => {
+    if (!window.performance) {
+        return false;
+    }
+
+    if (!isFunction(window.performance.mark) ||
+        !isFunction(window.performance.measure) ||
+        !isFunction(window.performance.clearMarks)) {
+        return false;
+    }
+
+    return true;
+};
+
+export const BEFORE_EACH_MARK_NAME = 'beforeEach';
+
+function perfInit(to, from, nameGenerator) {
+    if (!hasPerformanceAPI()) {
+        return;
+    }
+
+    window.performance.mark(nameGenerator(BEFORE_EACH_MARK_NAME, to, from));
+}
+
+export function perfMeasure(name, to, from, nameGenerator) {
+    if (!nameGenerator || !hasPerformanceAPI()) {
+        return;
+    }
+
+    const startingMark =
+        last(window.performance.getEntriesByName(nameGenerator(BEFORE_EACH_MARK_NAME, to, from)));
+
+    if (!startingMark) {
+        // do something else?
+        return;
+    }
+
+    window.performance.measure(
+        nameGenerator(name, to, from),
+        nameGenerator(BEFORE_EACH_MARK_NAME, to, from),
+    );
+}
+
+export function perfClear() {
+    if (!hasPerformanceAPI()) {
+        return;
+    }
+
+    window.performance.getEntriesByType('mark')
+        .filter(m => m.name.startsWith(BEFORE_EACH_MARK_NAME))
+        .forEach(m => window.performance.clearMarks(m.name));
+}
 
 export default function initializeClient(createApp, clientOpts) {
     const opts = {
@@ -16,6 +69,7 @@ export default function initializeClient(createApp, clientOpts) {
         middleware: () => Promise.resolve(),
         postMiddleware: () => Promise.resolve(),
         logger: console,
+        perfNameGenerator: null,
         ...clientOpts,
     };
 
@@ -123,6 +177,25 @@ export default function initializeClient(createApp, clientOpts) {
     // Register the fetchData hook once the router is ready since we don't want to
     // re-run fetchData for the SSR'd component
     router.onReady(() => {
+
+        router.beforeEach((to, from, next) => {
+            if (!isFunction(opts.perfNameGenerator)) {
+                next();
+                return;
+            }
+
+            const fetchDataArgs = { app, route: to, router, store, from };
+            const components = router.getMatchedComponents(to)
+                .filter(c => !shouldIgnoreRouteUpdate(c, fetchDataArgs));
+
+            // Only measure performance for non-ignored route changed
+            if (components.length > 0) {
+                perfInit(to, from, opts.perfNameGenerator);
+            }
+
+            next();
+        });
+
         // Prior to resolving a route, execute any component fetchData methods.
         // Approach based on:
         //   https://ssr.vuejs.org/en/data.html#client-data-fetching
@@ -143,12 +216,18 @@ export default function initializeClient(createApp, clientOpts) {
 
             opts.logger.debug(`Running middleware/fetchData for route update ${routeUpdateStr}`);
             return Promise.resolve()
+                .then(() => perfMeasure('beforeResolve', to, from, opts.perfNameGenerator))
                 .then(() => opts.middleware(to, from, store, app))
+                .then(() => perfMeasure('afterMiddleware', to, from, opts.perfNameGenerator))
                 .then(() => Promise.all(components.map(fetchData)))
                 // Proxy results through the chain
-                .then(results => opts.postMiddleware(to, from, store, app).then(() => results))
-                // Call next with the first non-null resolved value from fetchData
-                .then(results => next(results.find(r => r != null)))
+                .then((fetchDataResults) => {
+                    perfMeasure('afterFetchData', to, from, opts.perfNameGenerator);
+
+                    return opts.postMiddleware(to, from, store, app).then(() => fetchDataResults)
+                        // Call next with the first non-null resolved value from fetchData
+                        .then(middlewareResults => next(middlewareResults.find(r => r != null)));
+                })
                 .catch((e) => {
                     opts.logger.error('Error fetching component data, preventing routing');
                     opts.logger.error(e);


### PR DESCRIPTION
Adds a new `enablePerfMarks` option to `initializeClient` that turns on `performance.mark` and `performance.measure` calls during client side routing.  Enabling this option will provide the following calls to a client side routing operation, where `FromName` and `ToName` are the route names from `vue-router`:

```
performance.mark('urbnperf|FromName->ToName|start');
performance.measure('urbnperf|FromName->ToName|beforeResolve', 'urbnperf|FromName->ToName|start');
performance.measure('', 'urbnperf|FromName->ToName|middleware-complete');
performance.measure('', 'urbnperf|FromName->ToName|fetchData-complete');
```

We do not indicate any "done" state as it is assumed the client application will know better (i.e., after animations complete, etc.)
