### PR TITLE
Component.vuex supports arrays

### DIFF
--- a/src/entry-server.js
+++ b/src/entry-server.js
@@ -33,15 +33,17 @@ export default function initializeServer(createApp, serverOpts) {
                     // bundle
                     components
                         .filter(c => 'vuex' in c)
-                        .forEach((c) => {
+                        .map(c => c.vuex)
+                        .reduce((acc, xorxs) => acc.concat(xorxs), [])
+                        .forEach(({ moduleName, module }) => {
                             // Allow a function to be passed that can generate a route-aware
                             // module name
-                            const moduleName = typeof c.vuex.moduleName === 'function' ?
-                                c.vuex.moduleName({ $route: router.currentRoute }) :
-                                c.vuex.moduleName;
-                            opts.logger.info('Registering dynamic Vuex module:', moduleName);
-                            store.registerModule(moduleName, c.vuex.module, {
-                                preserveState: store.state[moduleName] != null,
+                            const name = typeof moduleName === 'function' ?
+                                moduleName({ $route: router.currentRoute }) :
+                                moduleName;
+                            opts.logger.info('Registering dynamic Vuex module:', name);
+                            store.registerModule(name, module, {
+                                preserveState: store.state[name] != null,
                             });
                         });
                 }


### PR DESCRIPTION
Adds support for arrays in addition to the original interface of a single map.  Both of these will now work:

```js
vuex: [{
    moduleName: 'module1',
    module: moduleA,
},{
    moduleName: 'module2',
    module: moduleB,
}],
```

```js
vuex: {
    moduleName: 'someModule',
    module: moduleA,
},
```