### PR TITLE
Don't call shouldIgnoreRouteUpdate for cross-route navigations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -1,6 +1,10 @@
-import { find, isFunction, isString } from 'lodash-es';
+import { get, find, isFunction, isString } from 'lodash-es';
 
+// We only ignore route updates between when routing between the same entries
+// in the routing table (i.e., Catch-All->Catch-All or PDP->PDP).  Never ignore
+// route updates between routing table entries.
 const shouldIgnoreRouteUpdate = (c, args) => (
+    get(args, 'from.name') === get(args, 'route.name') &&
     isFunction(c.shouldIgnoreRouteUpdate) &&
     c.shouldIgnoreRouteUpdate(args) === true
 );


### PR DESCRIPTION
The original intention of `shouldIgnoreRouteUpdate` is to allow a route-level component to indicate what level of granularity should trigger the `fetchData` lifecycle on routing operations when we're using the same components.  It was not intended to allow components to opt-out when routing to brand new routing entries (i.e., category -> pdp).  so this PR stops calling the method when the route entry changes based on `route.name` and will never ignore those routing operations.