### PR TITLE
Add handling of _ssr_ prefix state fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",


### PR DESCRIPTION
Adds support for stripping any Vuex SSR state fields that begin with `_ssr_` so that we can use them for memoization of computationally expensive getters methods during SSR since reactvity is disabled during SSR:

https://ssr.vuejs.org/guide/universal.html#data-reactivity-on-the-server
https://github.com/vuejs/vue/issues/10151