### PR TITLE
UW-24106 Update Vue npm dependencies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,12 +26,12 @@ This package attempts to provide a core set of functionality for Vue SSR apps, i
 
 ## Currently Supported Versions
 
-* `eslint@4.19.1`
-* `jest@23.1.0`
-* `vue@2.5.16`
-* `vue-loader@15.2.4`
-* `vue-server-renderer@2.5.16`
-* `webpack@4.10.2`
+* `eslint@6.8.0`
+* `jest@24.9.0`
+* `vue@2.6.12`
+* `vue-loader@15.8.3`
+* `vue-server-renderer@2.6.12`
+* `webpack@4.41.5`
 
 
 ## Why?

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -89,9 +89,6 @@ export default initializeServer(createApp, {
 
     // Wire up logic for route-level vuex modules?
     vuexModules: true,
-    // Provide a function which will return a promise of all initial
-    // i18n translations to be included
-    i18nLoader: null,
     // Logger instance
     logger: console
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,6 +2680,30 @@
         }
       }
     },
+    "@intlify/vue-i18n-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-loader/-/vue-i18n-loader-1.0.0.tgz",
+      "integrity": "sha512-y7LlpKEQ01u7Yq14l4VNlbFYEHMmSEH1QXXASOMWspj9ZcIdCebhhvHCHqk5Oy5Epw3PtoxyRJNpb6Wle5udgA==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "json5": "^2.1.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -2872,30 +2896,6 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
-      }
-    },
-    "@kazupon/vue-i18n-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.5.0.tgz",
-      "integrity": "sha512-Tp2mXKemf9/RBhI9CW14JjR9oKjL2KH7tV6S0eKEjIBuQBAOFNuPJu3ouacmz9hgoXbNp+nusw3MVQmxZWFR9g==",
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "json5": "^2.1.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "@types/babel__core": {
@@ -13797,16 +13797,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
-    },
-    "vue-i18n": {
-      "version": "8.15.3",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.15.3.tgz",
-      "integrity": "sha512-PVNgo6yhOmacZVFjSapZ314oewwLyXHjJwAqjnaPN1GJAJd/dvsrShGzSiJuCX4Hc36G4epJvNXUwO8y7wEKew=="
-    },
-    "vue-i18n-extensions": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vue-i18n-extensions/-/vue-i18n-extensions-0.2.1.tgz",
-      "integrity": "sha512-xBrItI7bEwBnG7eAlnyUARP41JYYn2+ABMR8q1Yh5FM9hHCbs4XPZwG+4+FPeIZ6b5gYk4YUP//m+fWiuU9z9A=="
     },
     "vue-jest": {
       "version": "3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/plugin-proposal-object-rest-spread": "7.10.4",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.10.4",
-    "@kazupon/vue-i18n-loader": "0.5.0",
+    "@intlify/vue-i18n-loader": "1.0.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "24.9.0",
@@ -52,8 +52,6 @@
     "terser-webpack-plugin": "2.3.8",
     "url-loader": "4.1.0",
     "vue": "2.6.12",
-    "vue-i18n": "8.15.3",
-    "vue-i18n-extensions": "0.2.1",
     "vue-jest": "3.0.5",
     "vue-loader": "15.8.3",
     "vue-server-renderer": "2.6.12",
@@ -69,10 +67,8 @@
   },
   "peerDependencies": {
     "lru-cache": "^6.0.0",
-    "vue": "^2.6.10",
-    "vue-i18n": "^8.7.0",
-    "vue-i18n-extensions": "^0.2.0",
-    "vue-server-renderer": "^2.6.10"
+    "vue": "^2.6.12",
+    "vue-server-renderer": "^2.6.12"
   },
   "devDependencies": {
     "husky": "1.3.1"

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -23,7 +23,6 @@ const errorHandler = (err, res, cb) => {
 const defaults = {
     name: 'default',
     errorHandler,
-    i18nDirective: false,
     isLocal: process.env.NODE_ENV === 'local',
     isDev: process.env.NODE_ENV === 'development',
     isProd: process.env.NODE_ENV === 'production',
@@ -48,10 +47,6 @@ const renderers = {};
 let readyPromise;
 
 function createRenderer(bundle, options, config) {
-    const t = config.i18nDirective ?
-        require('vue-i18n-extensions').directive :
-        null;
-
     if (caches[config.name]) {
         config.logger.debug(
             `Recreating the "${config.name}" Vue SSR BundleRenderer, clearing`,
@@ -86,8 +81,6 @@ function createRenderer(bundle, options, config) {
     return createBundleRenderer(bundle, Object.assign(options, {
         cache: caches[config.name],
         runInNewContext: false,
-        // Only include the t directive when specified
-        ...(t ? { directives: { t } } : {}),
     }, config.rendererOpts));
 }
 


### PR DESCRIPTION
Addressing changes [suggested here](https://github.com/urbn/SlipStream/pull/4242#discussion_r503298654)

- Remove vue-i18n and vue-i18n-extensions
- Update @kazupon/vue-i18n-loader to @intlify/vue-i18n-loader