### PR TITLE
fix existingModule check for modules registered prior to routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -132,10 +132,16 @@ export default function initializeClient(createApp, clientOpts) {
                         const name = getModuleName(c, to);
                         const existingModule = get(store, `_modulesNamespaceMap.${name}/`);
                         if (existingModule) {
-                            // We already have this module registered, update the
-                            // index to mark it as recent
                             opts.logger.info('Skipping duplicate Vuex module registration:', name);
-                            existingModule.index = moduleIndex++;
+                            // If the module was registered outside of the routing flow,
+                            // we need to add it to registeredModules.
+                            // Otherwise we will update the index to mark it as recent
+                            const registeredModule = find(registeredModules, { name });
+                            if (!registeredModule) {
+                                registeredModules.push({ name, index: moduleIndex++ });
+                            } else {
+                                registeredModule.index = moduleIndex++;
+                            }
                         } else {
                             opts.logger.info('Registering dynamic Vuex module:', name);
                             store.registerModule(name, c.vuex.module, {

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -130,7 +130,7 @@ export default function initializeClient(createApp, clientOpts) {
                     .filter(c => !shouldIgnoreRouteUpdate(c, fetchDataArgs))
                     .forEach((c) => {
                         const name = getModuleName(c, to);
-                        const existingModule = find(registeredModules, { name });
+                        const existingModule = get(store, `_modulesNamespaceMap.${name}/`);
                         if (existingModule) {
                             // We already have this module registered, update the
                             // index to mark it as recent


### PR DESCRIPTION
This fix ensures that when routing to a view for the first time, with the module registered beforehand, we do not attempt to register a duplicate module