### PR TITLE
UW-24672 Update category name in vue-ssr-build to be category instead of catch-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ssr-build",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Vue.js SSR Build Helper",
   "author": "matt@brophy.org",
   "license": "MIT",

--- a/src/entry-client.js
+++ b/src/entry-client.js
@@ -67,6 +67,28 @@ const perfEnabled = () => (
 const getCurrentPerfMark = () => window.performance.getEntriesByType('mark')
     .find(m => m.name.startsWith(PERF_PREFIX) && m.name.endsWith('start'));
 
+function perfMarkNameFromRoute(route) {
+    let result;
+    const routeName = get(route, 'name') || '';
+
+    if (routeName.toLowerCase() === 'catch-all') {
+        const slugParam = get(route, 'params.slug');
+
+        if (slugParam && slugParam !== '') {
+            result = `Category (${slugParam})`;
+        } else {
+            result = 'Category';
+        }
+    } else if (routeName !== '') {
+        result = routeName;
+    } else {
+        const pageType = get(route, 'meta.pageType');
+        result = pageType;
+    }
+
+    return result;
+}
+
 function perfInit(to, from) {
     if (!perfEnabled()) {
         return;
@@ -83,7 +105,8 @@ function perfInit(to, from) {
 
     // Start a new routing operation with a mark such as:
     //   urbnperf|Homepage->Catch-All|start
-    window.performance.mark(`${PERF_PREFIX}|${from.name}->${to.name}|start`);
+    window.performance.mark(
+        `${PERF_PREFIX}|${perfMarkNameFromRoute(from)}->${perfMarkNameFromRoute(to)}|start`);
 }
 
 // Issue a performance.measure call for the given name using the most recent


### PR DESCRIPTION
Use Category instead of Catch-All (include category slug if it exists) in performance marks around routing